### PR TITLE
Remove android:allowBackup from manifest

### DIFF
--- a/barcodescanner/src/main/AndroidManifest.xml
+++ b/barcodescanner/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="barcodescanner.xservices.nl.barcodescanner">
 
-  <application android:allowBackup="true"
-               android:label="@string/app_name"
+  <application android:label="@string/app_name"
     >
 
   </application>


### PR DESCRIPTION
A library shouldn't set android:allowBackup. It's up to the application itself to decide.