### PR TITLE
enable EAN extension results for UPC-A format

### DIFF
--- a/barcodescanner/src/main/java/com/google/zxing/oned/UPCAReader.java
+++ b/barcodescanner/src/main/java/com/google/zxing/oned/UPCAReader.java
@@ -77,7 +77,9 @@ public final class UPCAReader extends UPCEANReader {
   private static Result maybeReturnResult(Result result) throws FormatException {
     String text = result.getText();
     if (text.charAt(0) == '0') {
-      return new Result(text.substring(1), null, result.getResultPoints(), BarcodeFormat.UPC_A);
+      Result retval = new Result(text.substring(1), null, result.getResultPoints(), BarcodeFormat.UPC_A);
+      retval.putAllMetadata(result.getResultMetadata());
+      return retval;
     } else {
       throw FormatException.getFormatInstance();
     }


### PR DESCRIPTION
I have considered this to be a necessary update in order for me to get the `ResultMetadataType.UPC_EAN_EXTENSION` extra when I was enabling the EAN extensions.
The updates seems to me logical, useful yet harmless. And I can finally read UPC-A EAN-5 extended barcodes as this

![barcode](https://user-images.githubusercontent.com/10962296/40180277-b720c920-59e6-11e8-960d-89f7cb3d5ce7.jpg)

I have pointed this out to zxing team, and they already applied the change on the official repo. See the [issue](https://github.com/zxing/zxing/issues/217#ref-commit-2c2c395), and the [commit](https://github.com/zxing/zxing/commit/2c2c395afa9ba8fee13249bf5d02d13e19967207).